### PR TITLE
modify searchingSpec.js for searching algorithms

### DIFF
--- a/searching_algorithms_exercise/searchingSpec.js
+++ b/searching_algorithms_exercise/searchingSpec.js
@@ -7,8 +7,9 @@ describe("#linearSearch", function(){
     expect(linearSearch([1,2,3,4,5,6,7],6)).to.equal(5)
   });
   it("should return -1 if the value is not found", function(){
-    expect(linearSearch([1,2,3,4]),0).to.equal(-1)
-    expect(linearSearch([1,2]),11).to.equal(-1)
+    expect(linearSearch([1,2,3,4],0)).to.equal(-1)
+    expect(linearSearch([1,3,4],2)).to.equal(-1)
+    expect(linearSearch([1,2],11)).to.equal(-1)
   });
 });
 
@@ -19,8 +20,9 @@ describe("#linearSearchRecursive", function(){
     expect(linearSearchRecursive([1,2,3,4,5,6,7],6)).to.equal(5)
   });
   it("should return -1 if the value is not found", function(){
-    expect(linearSearchRecursive([1,2,3,4]),0).to.equal(-1)
-    expect(linearSearchRecursive([1,2]),11).to.equal(-1)
+    expect(linearSearchRecursive([1,2,3,4],0)).to.equal(-1)
+    expect(linearSearchRecursive([1,3,4],2)).to.equal(-1)
+    expect(linearSearchRecursive([1,2],11)).to.equal(-1)
   });
 });
 
@@ -31,8 +33,9 @@ describe("#binarySearch", function(){
     expect(binarySearch([1,2,3,4,5,6,7],6)).to.equal(5)
   });
   it("should return -1 if the value is not found", function(){
-    expect(binarySearch([1,2,3,4]),0).to.equal(-1)
-    expect(binarySearch([1,2]),11).to.equal(-1)
+    expect(binarySearch([1,2,3,4],0)).to.equal(-1)
+    expect(binarySearch([1,3,4],2)).to.equal(-1)
+    expect(binarySearch([1,2],11)).to.equal(-1)
   });
 });
 
@@ -43,7 +46,8 @@ describe("#binarySearchRecursive", function(){
     expect(binarySearchRecursive([1,2,3,4,5,6,7],6)).to.equal(5)
   });
   it("should return -1 if the value is not found", function(){
-    expect(binarySearchRecursive([1,2,3,4]),0).to.equal(-1)
-    expect(binarySearchRecursive([1,2]),11).to.equal(-1)
+    expect(binarySearchRecursive([1,2,3,4],0)).to.equal(-1)
+    expect(binarySearchRecursive([1,3,4],2)).to.equal(-1)
+    expect(binarySearchRecursive([1,2],11)).to.equal(-1)
   });
 });


### PR DESCRIPTION
Parentheses for search arguments were only on the array and not on the array and values. Also added one more test for values that are not outside the start/end values.